### PR TITLE
Updates

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,0 +1,257 @@
+# Based on volsync/Dockerfile
+
+######################################################################
+# Establish a common builder image for all golang-based images
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS golang-builder
+USER root
+WORKDIR /workspace
+# We don't vendor modules. Enforce that behavior
+ENV GOFLAGS=-mod=readonly
+ENV GO111MODULE=on
+ENV CGO_ENABLED=1
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=${TARGETOS:-linux}
+ENV GOARCH=${TARGETARCH}
+ENV GOEXPERIMENT=strictfipsruntime
+ENV BUILD_TAGS="strictfipsruntime"
+
+
+######################################################################
+# Build the manager binary
+FROM golang-builder AS manager-builder
+
+# Copy the Go Modules manifests & download dependencies
+COPY volsync/go.mod go.mod
+COPY volsync/go.sum go.sum
+RUN go mod download
+
+# Copy the go source
+COPY volsync/cmd/ cmd/
+COPY volsync/api/ api/
+COPY volsync/internal/ internal/
+
+# Build
+ARG version_arg="(unknown)"
+ARG tags_arg=${BUILD_TAGS}
+RUN go build -a -o manager -ldflags "-X=main.volsyncVersion=${version_arg}" -tags "${tags_arg}" ./cmd/...
+
+# Verify that FIPS crypto libs are accessible
+RUN nm manager | grep -q "goboringcrypto\|golang-fips"
+
+######################################################################
+# Build rclone
+FROM golang-builder AS rclone-builder
+
+ARG RCLONE_VERSION=v1.63.1
+ARG RCLONE_GIT_HASH=bd1fbcae12f795f498c7ace6af9d9cc218102094
+
+#RUN git clone --depth 1 -b ${RCLONE_VERSION} https://github.com/rclone/rclone.git
+COPY rclone/ rclone/
+WORKDIR /workspace/rclone
+
+# Make sure the Rclone version tag matches the git hash we're expecting
+#RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
+
+# Remove link flag that strips symbols so that we can verify crypto libs
+RUN sed -i 's/--ldflags "-s /--ldflags "/g' Makefile
+
+RUN GOTAGS=${BUILD_TAGS} make rclone
+
+# Verify that FIPS crypto libs are accessible
+RUN nm rclone | grep -q "goboringcrypto\|golang-fips"
+
+######################################################################
+# Build restic
+FROM golang-builder AS restic-builder
+
+COPY volsync/mover-restic/restic ./restic
+COPY volsync/mover-restic/minio-go ./minio-go
+
+WORKDIR /workspace/restic
+
+# Preserve symbols so that we can verify crypto libs
+RUN sed -i 's/preserveSymbols := false/preserveSymbols := true/g' build.go
+
+RUN go run build.go --enable-cgo --tags ${BUILD_TAGS}
+
+# Verify that FIPS crypto libs are accessible
+RUN nm restic | grep -q "goboringcrypto\|golang-fips"
+
+######################################################################
+# Build syncthing
+FROM golang-builder AS syncthing-builder
+
+ARG SYNCTHING_VERSION="v1.29.5"
+ARG SYNCTHING_GIT_HASH="f0b666269b6bdd1e8000e56e421367260e807479"
+
+#RUN git clone --depth 1 -b ${SYNCTHING_VERSION} https://github.com/syncthing/syncthing.git
+COPY syncthing/ syncthing/
+WORKDIR /workspace/syncthing
+
+#FIXME: remove
+RUN /bin/bash -c "ls -al"
+
+# Make sure we have the correct Syncthing release
+#RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${SYNCTHING_GIT_HASH} ]]"
+
+RUN go run build.go -no-upgrade -tags ${BUILD_TAGS}
+
+# Verify that FIPS crypto libs are accessible
+RUN nm bin/syncthing | grep -q "goboringcrypto\|golang-fips"
+
+######################################################################
+# Build diskrsync binary
+FROM golang-builder AS diskrsync-builder
+
+ARG DISKRSYNC_VERSION="v1.3.0"
+ARG DISKRSYNC_GIT_HASH="507805c4378495fc2267b77f6eab3d6bb318c86c"
+
+#RUN git clone --depth 1 -b ${DISKRSYNC_VERSION} https://github.com/dop251/diskrsync.git
+COPY diskrsync/ diskrsync/
+WORKDIR /workspace/diskrsync
+
+#FIXME: remove
+RUN /bin/bash -c "ls -al"
+
+# Make sure we have the correct diskrsync release
+#RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${DISKRSYNC_GIT_HASH} ]]"
+
+RUN go build -a -o bin/diskrsync -tags ${BUILD_TAGS} ./diskrsync
+
+# Verify that FIPS crypto libs are accessible
+# RUN nm bin/diskrsync | grep -q "goboringcrypto\|golang-fips"
+
+
+######################################################################
+# Build diskrsync-tcp binary
+FROM golang-builder AS diskrsync-tcp-builder
+
+# Copy the Go Modules manifests & download dependencies
+COPY volsync/go.mod go.mod
+COPY volsync/go.sum go.sum
+RUN go mod download
+
+# Copy the go source
+COPY volsync/diskrsync-tcp/ diskrsync-tcp/
+
+# Build
+ARG version_arg="(unknown)"
+RUN go build -a -o diskrsync-tcp/diskrsync-tcp -ldflags "-X=main.volsyncVersion=${version_arg}" -tags ${BUILD_TAGS} diskrsync-tcp/main.go
+
+# Verify that FIPS crypto libs are accessible
+RUN nm diskrsync-tcp/diskrsync-tcp | grep -q "goboringcrypto\|golang-fips"
+
+######################################################################
+# Final container
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
+WORKDIR /
+
+RUN microdnf --refresh update -y && \
+    microdnf --nodocs --setopt=install_weak_deps=0 install -y \
+        acl             `# rclone - getfacl/setfacl` \
+        openssh         `# rsync/ssh - ssh key generation in operator` \
+        openssh-clients `# rsync/ssh - ssh client` \
+        openssh-server  `# rsync/ssh - ssh server` \
+        perl            `# rsync/ssh - rrsync script` \
+        stunnel         `# rsync-tls` \
+        openssl         `# syncthing - server certs` \
+        vim-minimal     `# for mover debug` \
+        tar             `# for mover debug` \
+    && microdnf --setopt=install_weak_deps=0 install -y \
+        `# docs are needed so rrsync gets installed for ssh variant` \
+        rsync           `# rsync/ssh, rsync-tls - rsync, rrsync` \
+    && microdnf clean all && \
+    rm -rf /var/cache/yum
+
+##### VolSync operator
+COPY --from=manager-builder /workspace/manager /manager
+
+##### rclone
+COPY --from=rclone-builder /workspace/rclone/rclone /usr/local/bin/rclone
+COPY volsync/mover-rclone/active.sh \
+     /mover-rclone/
+RUN chmod a+rx /mover-rclone/*.sh
+
+##### restic
+COPY --from=restic-builder /workspace/restic/restic /usr/local/bin/restic
+COPY volsync/mover-restic/entry.sh \
+     /mover-restic/
+RUN chmod a+rx /mover-restic/*.sh
+
+##### rsync (ssh)
+COPY volsync/mover-rsync/source.sh \
+     volsync/mover-rsync/destination.sh \
+     volsync/mover-rsync/destination-command.sh \
+     /mover-rsync/
+RUN chmod a+rx /mover-rsync/*.sh
+
+RUN ln -s /keys/destination /etc/ssh/ssh_host_rsa_key && \
+    ln -s /keys/destination.pub /etc/ssh/ssh_host_rsa_key.pub && \
+    install /usr/share/doc/rsync/support/rrsync /usr/local/bin && \
+    \
+    SSHD_CONFIG="/etc/ssh/sshd_config" && \
+    sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ecdsa_key\)$|#\1|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(.*/etc/ssh/ssh_host_ed25519_key\)$|#\1|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(PasswordAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(KbdInteractiveAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(AllowTcpForwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(PermitTunnel\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(PidFile\)\s.*$|\1 /tmp/sshd.pid|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
+    \
+    INCLUDED_SSH_CONFIG_DIR="/etc/ssh/sshd_config.d" && \
+    sed -ir 's|^[#\s]*\(UsePAM\)\s.*$|\1 no|' "$INCLUDED_SSH_CONFIG_DIR"/* && \
+    sed -ir 's|^[#\s]*\(GSSAPIAuthentication\)\s.*$|\1 no|' "$INCLUDED_SSH_CONFIG_DIR"/*
+
+##### rsync-tls
+COPY volsync/mover-rsync-tls/client.sh \
+     volsync/mover-rsync-tls/server.sh \
+     /mover-rsync-tls/
+RUN chmod a+rx /mover-rsync-tls/*.sh
+
+##### syncthing
+COPY --from=syncthing-builder /workspace/syncthing/bin/syncthing /usr/local/bin/syncthing
+ENV SYNCTHING_DATA_TRANSFERMODE="sendreceive"
+COPY volsync/mover-syncthing/config-template.xml \
+     /mover-syncthing/
+RUN chmod a+r /mover-syncthing/config-template.xml
+
+COPY volsync/mover-syncthing/config-template.xml \
+     volsync/mover-syncthing/stignore-template \
+     volsync/mover-syncthing/entry.sh \
+     /mover-syncthing/
+RUN chmod a+r /mover-syncthing/config-template.xml && \
+    chmod a+r /mover-syncthing/stignore-template && \
+    chmod a+rx /mover-syncthing/*.sh
+
+##### diskrsync
+COPY --from=diskrsync-builder /workspace/diskrsync/bin/diskrsync /usr/local/bin/diskrsync
+
+##### diskrsync-tcp
+COPY --from=diskrsync-tcp-builder /workspace/diskrsync-tcp/diskrsync-tcp /diskrsync-tcp
+
+##### Set build metadata
+ARG builddate_arg="(unknown)"
+ARG version_arg="(unknown)"
+ENV builddate="${builddate_arg}"
+ENV version="${version_arg}"
+
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.base.name="registry.redhat.io/ubi9/ubi-minimal"
+LABEL org.opencontainers.image.created="${builddate}"
+LABEL org.opencontainers.image.description="VolSync data replication operator"
+LABEL org.opencontainers.image.documentation="https://volsync.readthedocs.io/"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
+LABEL org.opencontainers.image.revision="${version}"
+LABEL org.opencontainers.image.source="https://github.com/backube/volsync"
+LABEL org.opencontainers.image.title="VolSync"
+LABEL org.opencontainers.image.vendor="Backube"
+LABEL org.opencontainers.image.version="${version}"
+
+# uid/gid: nobody/nobody
+USER 65534:65534
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # volsync-operator-product-build
 VolSync Operator Product Build to build downstream VolSync via Konflux
+
+## Getting Started
+
+This repo contains submodules in order to have all the dependencies
+to build the VolSync Operator.
+
+Current submodules:
+
+- [volsync](volsync) - points to https://github.com/volsync/volsync
+- [rclone](rclone) - points to https://github.com/rclone/rclone
+- [syncthing](syncthing) - points to https://github.com/syncthing/syncthing
+- [diskrsync](diskrsync) - points to https://github.com/dop251/diskrsync
+
+To clone this repo and submodules it can be done in one step with:
+
+```bash
+git clone https://github.com/stolostron/volsync-operator-product-build.git --recurse-submodules
+```
+
+Or, after cloning the repo you can do this to pull the submodules:
+
+```bash
+cd volsync-operator-product-build
+git submodule update --init --recursive
+```


### PR DESCRIPTION
- Add Dockerfile.rhtap (based on volsync/Dockerfile, but with some updates):
  - Builds rclone, syncthing, diskrsync from modules
  - Builds volsync, restic, diskrsync-tcp from volsync module
  - Removes checks to confirm git hashes are correct - will need to come up with an alternative (or check perhaps at PR time to make sure submodule git verions match expected ones in VolSync)
- update README with submodule info