### PR TITLE
make sure dep checker is run in dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Check that things are at the correct versions
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS dependency-checker
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS dep-checker-and-golang-builder
 
 WORKDIR /tmp
 
@@ -41,7 +41,7 @@ RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${DISKRSYNC_GIT_HASH} ]]"
 
 ######################################################################
 # Establish a common builder image for all golang-based images
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 AS golang-builder
+FROM dep-checker-and-golang-builder AS golang-builder
 USER root
 WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior


### PR DESCRIPTION
- docker buildx may skip unused stages, and the dependency checker wasn't used by the final stage.
- Instead, use dependency checker img as the base for the golang builder since it's using the same golang base img anyway.