### PR TITLE
Update to run if all submodules updated

### DIFF
--- a/.tekton/volsync-0-13-pull-request.yaml
+++ b/.tekton/volsync-0-13-pull-request.yaml
@@ -15,6 +15,9 @@ metadata:
       ".tekton/volsync-0-13-push.yaml".pathChanged() ||
       "Dockerfile.rhtap".pathChanged() ||
       "volsync".pathChanged() ||
+      "rclone".pathChanged() ||
+      "syncthing".pathChanged() ||
+      "diskrsync".pathChanged() ||
       "rpms.in.yaml".pathChanged() ||
       "rpms.lock.yaml".pathChanged())
   creationTimestamp: null

--- a/.tekton/volsync-0-13-push.yaml
+++ b/.tekton/volsync-0-13-push.yaml
@@ -14,6 +14,9 @@ metadata:
       ".tekton/volsync-0-13-push.yaml".pathChanged() ||
       "Dockerfile.rhtap".pathChanged() ||
       "volsync".pathChanged() ||
+      "rclone".pathChanged() ||
+      "syncthing".pathChanged() ||
+      "diskrsync".pathChanged() ||
       "rpms.in.yaml".pathChanged() ||
       "rpms.lock.yaml".pathChanged())
   creationTimestamp: null


### PR DESCRIPTION
- this can help catch if a submodule such as rclone is updated without the matching update in volsync