### PR TITLE
Try to allow to update update_bundle.sh when container is built

### DIFF
--- a/.tekton/volsync-0-13-push.yaml
+++ b/.tekton/volsync-0-13-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*Containerfile.*, .*update_bundle.sh"
     build.appstudio.openshift.io/repo: https://github.com/stolostron/volsync-operator-product-build?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
- See also in the volsync component, it's set to nudge the volsync-bundle build - this will hopefully allow it to update the bundle-hack/update_bundle.sh script with the latest volsync image SHA