### PR TITLE
pin rbac-proxy img to digest

### DIFF
--- a/rhtap-buildargs.conf
+++ b/rhtap-buildargs.conf
@@ -20,7 +20,7 @@ ARG_DISKRSYNC_GIT_HASH="507805c4378495fc2267b77f6eab3d6bb318c86c"
 # See https://konflux.pages.redhat.com/docs/users/building/component-nudges.html
 ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC="quay.io/redhat-user-workloads/volsync-tenant/volsync-0-13@sha256:3cc26ebeed322fe42dd39486f296d207583f5abcf8b1e9ed908fd58f878f923d"
 
-ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC="registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.17"
+ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC="registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18@sha256:d37a6d10b0fa07370066a31fdaffe2ea553faf4e4e98be7fcef5ec40d62ffe29"
 
 # ACM 2.14 doclink
 ARG_ACM_DOCLINK="https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/business_continuity/business-cont-overview#volsync"


### PR DESCRIPTION
Keeping the tag in the image link should allow renovate/mintmaker to keep this image digest up-to-date

see: https://docs.renovatebot.com/docker/#digest-pinning