### PR TITLE
[release-0.13] Manually nudge the volsync build the bundle will pickup

### DIFF
--- a/rhtap-buildargs.conf
+++ b/rhtap-buildargs.conf
@@ -19,9 +19,9 @@ ARG_DISKRSYNC_GIT_HASH="507805c4378495fc2267b77f6eab3d6bb318c86c"
 
 # Related images - will need to be kept updated with latest via component nudges
 # See https://konflux.pages.redhat.com/docs/users/building/component-nudges.html
-# 
+#
 # Note:  do NOT surround these with "" as this does something strange with the output from bundle-hack/update-bundle.sh
-ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/volsync-tenant/volsync-0-13@sha256:8b1301dba4648533e03ce882932c96d6fe73dee1cb10297579bbd6e89df193a4
+ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/volsync-tenant/volsync-0-13@sha256:90d399736ca81bb244415efaf05738beff806912a6ac7444a7d4839089b7a081
 
 ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC=registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18@sha256:d37a6d10b0fa07370066a31fdaffe2ea553faf4e4e98be7fcef5ec40d62ffe29
 


### PR DESCRIPTION
- move to latest volsync-0-13 image
- doing this manually as the nudge didn't happen for some reason