### PR TITLE
renovate updates for v0.14

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "baseBranches": [
     "main",
     "release-0.12",
-    "release-0.13"
+    "release-0.13",
+    "release-0.14"
   ],
   "updateNotScheduled": true,
   "ignorePaths": [
@@ -25,5 +26,18 @@
     "schedule": [
       "at any time"
     ]
-  }
+  },
+  "pinDigests": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["rhtap-buildargs.conf"],
+      "matchStrings": [
+        "ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC=(?<depName>[^<:]*?)(?::(?<currentValue>[^<]*?))?(?:@(?<currentDigest>sha256:[a-f0-9]+))"
+      ],
+      "autoReplaceStringTemplate": "ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC=\"{{{depName}}}:{{{newValue}}}@{{{newDigest}}}\"",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
- Also attempt to update rhtap-buildargs.conf by renovate to only update the dockerfile reference for the kube-rbac-proxy image.

  Note that we don't want renovate updating the volsync image ref (ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC). It should get updated automatically by the volsync component nudging the rhtap-buildargs.conf file.