### PR TITLE
[release-0.14] Manually update with first v0.14.0 img in rhtap-buildargs.conf

### DIFF
--- a/rhtap-buildargs.conf
+++ b/rhtap-buildargs.conf
@@ -21,7 +21,7 @@ ARG_DISKRSYNC_GIT_HASH="507805c4378495fc2267b77f6eab3d6bb318c86c"
 # See https://konflux.pages.redhat.com/docs/users/building/component-nudges.html
 #
 # Note:  do NOT surround these with "" as this does something strange with the output from bundle-hack/update-bundle.sh
-ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/volsync-tenant/volsync-0-13@sha256:90d399736ca81bb244415efaf05738beff806912a6ac7444a7d4839089b7a081
+ARG_STAGE_VOLSYNC_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/volsync-tenant/volsync-0-14@sha256:217f2b1f36e0a089c7c3a2d37a886686c5fa2522056d5d12626c61d3b74a34c3
 
 ARG_OSE_KUBE_RBAC_PROXY_IMAGE_PULLSPEC=registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18@sha256:d37a6d10b0fa07370066a31fdaffe2ea553faf4e4e98be7fcef5ec40d62ffe29
 


### PR DESCRIPTION
Subsequent updates to this image in rhtap-buildargs.conf should all happen via the nudge from the volsync-0-14 component.