### PR TITLE
Version v0.13.1 downstream

### DIFF
--- a/rhtap-buildargs.conf
+++ b/rhtap-buildargs.conf
@@ -3,7 +3,7 @@
 ##################################################################################################
 
 # VolSync version
-ARG_VERSION=0.13.0
+ARG_VERSION=0.13.1
 ARG_SUPPORTED_OCP_VERSIONS=v4.12-v4.20
 
 # Mover versions


### PR DESCRIPTION
- We have released v0.13.0 so enables us to update and keep building downstream on release-0.13.