### PR TITLE
[Release 0.12] CVE updates restic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 	path = CVE-patches/jwt_v4.5.2
 	url = https://github.com/golang-jwt/jwt
   branch = v4
+[submodule "CVE-patches/jwt_v5.2.2"]
+	path = CVE-patches/jwt_v5.2.2
+	url = https://github.com/golang-jwt/jwt
+  branch = v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,8 +25,8 @@
 [submodule "CVE-patches/jwt_v4.5.2"]
 	path = CVE-patches/jwt_v4.5.2
 	url = https://github.com/golang-jwt/jwt
-  branch = v4
+	branch = v4
 [submodule "CVE-patches/jwt_v5.2.2"]
 	path = CVE-patches/jwt_v5.2.2
 	url = https://github.com/golang-jwt/jwt
-  branch = v5
+	branch = v5

--- a/.tekton/volsync-0-12-pull-request.yaml
+++ b/.tekton/volsync-0-12-pull-request.yaml
@@ -40,6 +40,7 @@ spec:
     - {"type": "gomod", "path": "syncthing/"}
     - {"type": "gomod", "path": "diskrsync/"}
     - {"type": "gomod", "path": "CVE-patches/jwt_v4.5.2"}
+    - {"type": "gomod", "path": "CVE-patches/jwt_v5.2.2"}
     - {"type": "rpm", "path": "."}
   - name: build-args-file
     value: "rhtap-buildargs.conf"

--- a/.tekton/volsync-0-12-push.yaml
+++ b/.tekton/volsync-0-12-push.yaml
@@ -40,6 +40,7 @@ spec:
     - {"type": "gomod", "path": "syncthing/"}
     - {"type": "gomod", "path": "diskrsync/"}
     - {"type": "gomod", "path": "CVE-patches/jwt_v4.5.2"}
+    - {"type": "gomod", "path": "CVE-patches/jwt_v5.2.2"}
     - {"type": "rpm", "path": "."}
   - name: build-args-file
     value: "rhtap-buildargs.conf"

--- a/CVE-patches/patch_restic.sh
+++ b/CVE-patches/patch_restic.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+export CVE_PATCHES_DIR=CVE-patches
+export RESTIC_DIR=restic
+
+set -x
+env
+
+set -e -o pipefail
+
+# Replace jwt (v5) in restic
+cat <<EOF >>"${RESTIC_DIR}"/go.mod
+
+replace github.com/golang-jwt/jwt/v5 => ../${CVE_PATCHES_DIR}/jwt_v5.2.2
+EOF
+

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -110,7 +110,12 @@ FROM golang-builder AS restic-builder
 COPY volsync/mover-restic/restic ./restic
 COPY volsync/mover-restic/minio-go ./minio-go
 
+# Patch CVEs
+COPY CVE-patches/ CVE-patches/
+RUN ./CVE-patches/patch_restic.sh
+
 WORKDIR /workspace/restic
+RUN go mod download
 
 # Preserve symbols so that we can verify crypto libs
 RUN sed -i 's/preserveSymbols := false/preserveSymbols := true/g' build.go


### PR DESCRIPTION
- attempt to update jwt/v5 v5.2.1 that is included in restic v0.17.z with v5.2.2.

This is to fix CVE-2025-30204


For: https://issues.redhat.com/browse/ACM-19271