### PR TITLE
update renovate to ignore CVE-patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
   ],
   "updateNotScheduled": true,
   "ignorePaths": [
-    "**/drift-cache/**"
+    "**/drift-cache/**",
+    "**/CVE-patches/**"
   ],
   "ignoreDeps": [
     "rclone",


### PR DESCRIPTION
CVE-patches dir will be used for specific patching of exact versions we want - so have renovate ignore this dir.