### PR TITLE
[release-0.12] Do not build bundle when rpms.lock* is updated

### DIFF
--- a/.tekton/volsync-bundle-0-12-pull-request.yaml
+++ b/.tekton/volsync-bundle-0-12-pull-request.yaml
@@ -15,9 +15,7 @@ metadata:
        ".tekton/volsync-bundle-0-12-push.yaml".pathChanged() ||
        "bundle.Dockerfile.rhtap".pathChanged() ||
        "bundle-hack/***".pathChanged() ||
-       "rhtap-buildargs.conf".pathChanged() ||
-       "rpms.in.yaml".pathChanged() ||
-       "rpms.lock.yaml".pathChanged())
+       "rhtap-buildargs.conf".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: volsync-0-12

--- a/.tekton/volsync-bundle-0-12-push.yaml
+++ b/.tekton/volsync-bundle-0-12-push.yaml
@@ -14,9 +14,7 @@ metadata:
        ".tekton/volsync-bundle-0-12-push.yaml".pathChanged() ||
        "bundle.Dockerfile.rhtap".pathChanged() ||
        "bundle-hack/***".pathChanged() ||
-       "rhtap-buildargs.conf".pathChanged() ||
-       "rpms.in.yaml".pathChanged() ||
-       "rpms.lock.yaml".pathChanged())
+       "rhtap-buildargs.conf".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: volsync-0-12


### PR DESCRIPTION
- not necessary as bundle img is based of scratch image and also we'll get a nudge pr once rpms are updated (which triggers the container build, which then will trigger a nudge pr for the bundle)