### PR TITLE
[release-0.14] Do not build bundle when rpms.lock* is updated

### DIFF
--- a/.tekton/volsync-bundle-0-14-pull-request.yaml
+++ b/.tekton/volsync-bundle-0-14-pull-request.yaml
@@ -15,9 +15,7 @@ metadata:
       ".tekton/volsync-bundle-0-14-push.yaml".pathChanged() ||
       "bundle.Dockerfile.rhtap".pathChanged() ||
       "bundle-hack/***".pathChanged() ||
-      "rhtap-buildargs.conf".pathChanged() ||
-      "rpms.in.yaml".pathChanged() ||
-      "rpms.lock.yaml".pathChanged())
+      "rhtap-buildargs.conf".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: volsync-0-14

--- a/.tekton/volsync-bundle-0-14-push.yaml
+++ b/.tekton/volsync-bundle-0-14-push.yaml
@@ -14,9 +14,7 @@ metadata:
       ".tekton/volsync-bundle-0-14-push.yaml".pathChanged() ||
       "bundle.Dockerfile.rhtap".pathChanged() ||
       "bundle-hack/***".pathChanged() ||
-      "rhtap-buildargs.conf".pathChanged() ||
-      "rpms.in.yaml".pathChanged() ||
-      "rpms.lock.yaml".pathChanged())
+      "rhtap-buildargs.conf".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: volsync-0-14


### PR DESCRIPTION
- not necessary as bundle img is based of scratch image and also we'll get a nudge pr once rpms are updated (which triggers the container build, which then will trigger a nudge pr for the bundle)