### PR TITLE
Add falconizmi to OWNERS (release-0.13)

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - gurnben
   - sahare
   - birsanv
+  - falconizmi
 reviewers:
   - JohnStrunk
   - jnpacker
@@ -14,3 +15,4 @@ reviewers:
   - gurnben
   - sahare
   - birsanv
+  - falconizmi


### PR DESCRIPTION
## Summary
Cherry-pick commit 82dc07d from main branch to add falconizmi to the OWNERS file in release-0.13 branch.

This grants falconizmi approval and review permissions for the release-0.13 branch.

## Changes
- Added falconizmi to both approvers and reviewers sections in OWNERS file

🤖 Generated with [Claude Code](https://claude.ai/code)