### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for volsync-bundle-0-13

### DIFF
--- a/bundle.Dockerfile.rhtap
+++ b/bundle.Dockerfile.rhtap
@@ -85,7 +85,8 @@ LABEL com.redhat.component="volsync-operator-bundle-container" \
       maintainer="['acm-component-maintainers@redhat.com']" \
       description="volsync-operator-bundle" \
       vendor="Red Hat, Inc." \
-      #TODO: Should these be set here?
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
+      #TODO: Should these be set here? \
       url="https://github.com/stolostron/volsync-operator-product-build" \
       release="0" \
       distribution-scope="public"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
