### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for volsync-0-13

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -273,7 +273,8 @@ LABEL com.redhat.component="volsync-container" \
       vendor="Red Hat, Inc." \
       url="https://github.com/stolostron/volsync-operator-product-build" \
       release="0" \
-      distribution-scope="public"
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:acm:2.14::el9"
 
 # License
 RUN mkdir licenses/


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
