### PR TITLE
[release-0.14] chore(KONFLUX-6210): fix and set name and cpe label for volsync-bundle-0-14

### DIFF
--- a/bundle.Dockerfile.rhtap
+++ b/bundle.Dockerfile.rhtap
@@ -85,7 +85,8 @@ LABEL com.redhat.component="volsync-operator-bundle-container" \
       maintainer="['acm-component-maintainers@redhat.com']" \
       description="volsync-operator-bundle" \
       vendor="Red Hat, Inc." \
-      #TODO: Should these be set here?
+      cpe="cpe:/a:redhat:acm:2.15::el9" \
+      #TODO: Should these be set here? \
       url="https://github.com/stolostron/volsync-operator-product-build" \
       release="0" \
       distribution-scope="public"


### PR DESCRIPTION
## Summary
Update labels in bundle.Dockerfile.rhtap for volsync-bundle-0-14 to include the cpe label for ACM 2.15.

This change ensures proper security scanning integration and follows the established pattern from other ACM components.

### Changes
- Added cpe label: `cpe:/a:redhat:acm:2.15::el9`

Based on original PR: #293

Created-by: Claude AI