### PR TITLE
[release-0.12] chore(KONFLUX-6210): fix and set name and cpe label for volsync-0-12

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -279,7 +279,8 @@ LABEL com.redhat.component="volsync-container" \
       vendor="Red Hat, Inc." \
       url="https://github.com/stolostron/volsync-operator-product-build" \
       release="0" \
-      distribution-scope="public"
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:acm:2.13::el9"
 
 # License
 RUN mkdir licenses/


### PR DESCRIPTION
## Summary
Update labels in Dockerfile.rhtap for volsync-0-12 to include the cpe label for ACM 2.13.

This change ensures proper security scanning integration and follows the established pattern from other ACM components.

### Changes
- Added cpe label: `cpe:/a:redhat:acm:2.13::el9`

Based on original PR: #294

Created-by: Claude AI