### PR TITLE
Build volsync container with golang 1.24 - release-0.13

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Check that submodules for movers are at the correct versions
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS dep-checker-and-golang-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24@sha256:b91431604c435f3cabec20ddb653c0537c8ba8097ada57960d54a1266f95a7c3 AS dep-checker-and-golang-builder
 
 WORKDIR /tmp
 

--- a/bundle.Dockerfile.rhtap
+++ b/bundle.Dockerfile.rhtap
@@ -1,5 +1,5 @@
 # Based on ./volsync/bundle.Dockerfile
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:96cfceb50f5323efa1aa8569d4420cdbf1bb391225d5171ef72a0d0ecf028467 AS builder-runner
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24@sha256:b91431604c435f3cabec20ddb653c0537c8ba8097ada57960d54a1266f95a7c3 AS builder-runner
 
 ENV GOFLAGS=-mod=readonly
 

--- a/drift-cache/volsync/Dockerfile.cached
+++ b/drift-cache/volsync/Dockerfile.cached
@@ -1,6 +1,6 @@
 ######################################################################
 # Establish a common builder image for all golang-based images
-FROM golang:1.23 AS golang-builder
+FROM golang:1.24 AS golang-builder
 USER root
 WORKDIR /workspace
 # We don't vendor modules. Enforce that behavior
@@ -46,7 +46,8 @@ WORKDIR /workspace/rclone
 # Make sure the Rclone version tag matches the git hash we're expecting
 RUN /bin/bash -c "[[ $(git rev-list -n 1 HEAD) == ${RCLONE_GIT_HASH} ]]"
 
-RUN make rclone
+# Tell Go to use the standard BFD linker instead of gold
+RUN make rclone BUILD_ARGS="-ldflags='-extldflags=-fuse-ld=bfd'"
 
 
 ######################################################################


### PR DESCRIPTION
Updating to build with golang 1.24 for future maintenance
Currently for this PR: https://github.com/stolostron/volsync-operator-product-build/pull/104