### PR TITLE
Update renovate to rebase when branch is behind

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,5 +43,6 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
-  ]
+  ],
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
Its headache to always manually rebase old renovate PRs. This should make our job easy and keep the PRs up to date with branches that they are merging to.