### PR TITLE
Bring back base branch name in the PR title

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,5 +37,6 @@
       "versioningTemplate": "docker"
     }
   ],
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "commitMessage": "[{{{baseBranch}}}] {{{commitMessage}}}"
 }


### PR DESCRIPTION
When the basebranchpattern was removed from renovate.json, we lost the base brancha name from the PR title. This change will bring it back while not losing the incoming PR title 