### PR TITLE
[release-0.12] build all platforms on pushes

### DIFF
--- a/.tekton/volsync-0-12-pull-request.yaml
+++ b/.tekton/volsync-0-12-pull-request.yaml
@@ -58,6 +58,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile.rhtap
   taskRunSpecs:


### PR DESCRIPTION
matches our other branches, helps catch errors on things like rpm lockfile updates where mismatches between arches can cause failures down then line once we start building multi-arch.