### PR TITLE
explicitely require findutils in final container

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -169,6 +169,7 @@ WORKDIR /
 
 RUN microdnf --refresh update -y && \
     microdnf --nodocs --setopt=install_weak_deps=0 install -y \
+        findutils        `# used by various mover scripts` \
         acl              `# rclone - getfacl/setfacl` \
         openssh          `# rsync/ssh - ssh key generation in operator` \
         openssh-clients  `# rsync/ssh - ssh client` \

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -6,6 +6,7 @@ contentOrigin:
       baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/${basearch}/appstream/os/
 packages:
   # For Volsync final image (see Dockerfile.rhtap)
+  - findutils
   - acl
   - openssh
   - openssh-clients

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -53,6 +53,13 @@ arches:
     name: expat
     evr: 2.5.0-5.el9_7.1
     sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/f/findutils-4.8.0-7.el9.aarch64.rpm
+    repoid: ubi-9-for-aarch64-baseos-rpms
+    size: 564807
+    checksum: sha256:158af4d5ecbd8b87f0da762ea1655bd4c86512071a95d8307eda3e0b3991105d
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/aarch64/baseos/os/Packages/g/gzip-1.12-1.el9.aarch64.rpm
     repoid: ubi-9-for-aarch64-baseos-rpms
     size: 169809
@@ -309,6 +316,13 @@ arches:
     name: expat
     evr: 2.5.0-5.el9_7.1
     sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/f/findutils-4.8.0-7.el9.ppc64le.rpm
+    repoid: ubi-9-for-ppc64le-baseos-rpms
+    size: 603076
+    checksum: sha256:d4662cea7b9ae75c86e6afa1c69b3047773acf7d4a6cf8b99e63355cde0e8de8
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/ppc64le/baseos/os/Packages/g/gzip-1.12-1.el9.ppc64le.rpm
     repoid: ubi-9-for-ppc64le-baseos-rpms
     size: 175705
@@ -572,6 +586,13 @@ arches:
     name: expat
     evr: 2.5.0-5.el9_7.1
     sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/f/findutils-4.8.0-7.el9.s390x.rpm
+    repoid: ubi-9-for-s390x-baseos-rpms
+    size: 562344
+    checksum: sha256:58a784cd8f94da5182ab13c9696c7e5410b0452b20c524013040d234517e931e
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/s390x/baseos/os/Packages/g/gzip-1.12-1.el9.s390x.rpm
     repoid: ubi-9-for-s390x-baseos-rpms
     size: 173101
@@ -828,6 +849,13 @@ arches:
     name: expat
     evr: 2.5.0-5.el9_7.1
     sourcerpm: expat-2.5.0-5.el9_7.1.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/f/findutils-4.8.0-7.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 563531
+    checksum: sha256:a6328afea0a11647b7fb5c48436f0af6c795407bac0650676d3196dd47070de6
+    name: findutils
+    evr: 1:4.8.0-7.el9
+    sourcerpm: findutils-4.8.0-7.el9.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/gzip-1.12-1.el9.x86_64.rpm
     repoid: ubi-9-for-x86_64-baseos-rpms
     size: 171206


### PR DESCRIPTION
- with removal of perl, findutils is not automatically pulled in anymore
- normally running `microdnf --refresh update -y` (which we do in the docker build) will pull in findutils automatically, but since we're using an offline build with rpms.lock.yaml, findutils isn't there uniess we explicitly add it.
- technically we could probably only add findutils to rpms.in.yaml/rpms.lock.yaml and let microdnf --refresh update -y pick it up for us, but think it's safer to explicitly install it in the dockerfile as well