### PR TITLE
Bump to 0.16.1

### DIFF
--- a/rhtap-buildargs.conf
+++ b/rhtap-buildargs.conf
@@ -3,7 +3,7 @@
 ##################################################################################################
 
 # VolSync version
-ARG_VERSION=0.16.0
+ARG_VERSION=0.16.1
 ARG_SUPPORTED_OCP_VERSIONS=v4.15-v4.23
 
 # Mover versions


### PR DESCRIPTION
Z-stream downstream bump: 0.16.0 → 0.16.1

Files updated:
- volsync submodule (→ upstream release-0.16 HEAD)
- rhtap-buildargs.conf (ARG_VERSION)